### PR TITLE
Handle NaN GPS values in `load_geo_from_exif` when Android file picke…

### DIFF
--- a/app/models/issues/draft.rb
+++ b/app/models/issues/draft.rb
@@ -124,7 +124,7 @@ class Issues::Draft < ApplicationRecord
     end
 
     gps = d[:gps]
-    if gps && gps[:gps_latitude] && gps[:gps_longitude]
+    if gps && valid_gps?(gps[:gps_latitude]) && valid_gps?(gps[:gps_longitude])
       self.latitude = gps_to_float(gps[:gps_latitude])
       self.longitude = gps_to_float(gps[:gps_longitude])
       self.latlon_from_exif = true
@@ -207,5 +207,9 @@ class Issues::Draft < ApplicationRecord
   def gps_to_float(gps)
     d, m, s = gps
     d.to_f + m / 60 + s / 3600
+  end
+
+  def valid_gps?(gps)
+    gps.is_a?(Array) && gps.length == 3 && gps.all? { |v| !v.to_f.nan? }
   end
 end

--- a/test/models/issues/draft_test.rb
+++ b/test/models/issues/draft_test.rb
@@ -1,7 +1,30 @@
 require "test_helper"
 
 class Issues::DraftTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "load_geo_from_exif does not set coordinates when GPS contains NaN values" do
+    user = users(:one)
+    draft = Issues::Draft.create!(author: user)
+
+    # Attach a fake photo
+    draft.photos.attach(io: StringIO.new("fake image"), filename: "photo.jpg", content_type: "image/jpeg")
+    photo = draft.photos.first
+
+    # Mock Exif::Data to return GPS with NaN values (Android empty GPS edge case)
+    exif_data_mock = Minitest::Mock.new
+    gps_data = {
+      gps_latitude: [ Float::NAN, Float::NAN, Float::NAN ],
+      gps_longitude: [ Float::NAN, Float::NAN, Float::NAN ]
+    }
+    exif_data_mock.expect(:[], gps_data, [ :gps ])
+
+    Exif::Data.stub :new, exif_data_mock do
+      draft.load_geo_from_exif(photo)
+    end
+
+    assert_nil draft.latitude, "Latitude should not be set when GPS contains NaN"
+    assert_nil draft.longitude, "Longitude should not be set when GPS contains NaN"
+    assert_not draft.latlon_from_exif
+
+    exif_data_mock.verify
+  end
 end


### PR DESCRIPTION
…r strips GPS from photos

Ked sa pouziva file picker, tak GPS koordinaty kvoli bezpecnosti android vyhodi. Tento okrajovy pripad sme nemali osetreny a ukazalo sa, ze on nie je tak okrajovy pre mna. nahlasujem totiz tak, ze po ceste si len nieco odfotim a potom to do ops nahravam neskor - a prave tu sa to pokazi. Scenar, ze otvorim OPS PWA/web a rovno uploadujem "z kamery" tak gps posiela. 