### PR TITLE
Fix SQL  in PgSearch::Faster fulltext_search

### DIFF
--- a/app/lib/pg_search/faster.rb
+++ b/app/lib/pg_search/faster.rb
@@ -2,13 +2,23 @@ module PgSearch
   module Faster
     extend ActiveSupport::Concern
 
+    DISALLOWED_TSQUERY_CHARACTERS = /['?\\:]/
+
     class_methods do
       def fulltext_search(query, against:, unaccent_f: "unaccent")
-        query_sql = query.split.compact.map do
+        sanitized_terms = sanitize_terms(query)
+
+        return none if sanitized_terms.empty?
+
+        query_sql = sanitized_terms.map do
           "to_tsquery('simple', ''' ' || #{unaccent_f}(?) || ' ''')"
         end.join(" && ")
 
-        where("#{fulltext_index_expression(against:, unaccent_f:)} @@ (#{query_sql})", *query.split.compact)
+        where("#{fulltext_index_expression(against:, unaccent_f:)} @@ (#{query_sql})", *sanitized_terms)
+      end
+
+      def sanitize_terms(query)
+        query.gsub(DISALLOWED_TSQUERY_CHARACTERS, " ").split.reject(&:empty?)
       end
 
       def fulltext_index_expression(against:, unaccent_f: "unaccent")

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "73bd92709f02ddbd8826ec99c4c2acf9dc235503aa5a82cea6330f20e427f317",
+      "fingerprint": "16987c8f23faaba879342d11caa5832509de79e78de5f77079e3ed0b336a4c27",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/lib/pg_search/faster.rb",
-      "line": 11,
+      "line": 17,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "where(\"#{fulltext_index_expression(:against => against, :unaccent_f => unaccent_f)} @@ (#{query.split.compact.map do\n \"to_tsquery('simple', ''' ' || #{unaccent_f}(?) || ' ''')\"\n end.join(\" && \")})\", *query.split.compact)",
+      "code": "where(\"#{fulltext_index_expression(:against => against, :unaccent_f => unaccent_f)} @@ (#{sanitize_terms(query).map do\n \"to_tsquery('simple', ''' ' || #{unaccent_f}(?) || ' ''')\"\n end.join(\" && \")})\", *sanitize_terms(query))",
       "render_path": null,
       "location": {
         "type": "method",
@@ -21,8 +21,8 @@
       "cwe_id": [
         89
       ],
-      "note": ""
+      "note": "Safe: 'against' contains only column names defined by developer, 'unaccent_f' is a controlled function name. User input is sanitized via sanitize_terms() and passed as bind parameters."
     }
   ],
-  "brakeman_version": "8.0.2"
+  "brakeman_version": "8.0.4"
 }

--- a/test/lib/pg_search/faster_test.rb
+++ b/test/lib/pg_search/faster_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class PgSearch::FasterTest < ActiveSupport::TestCase
+  test "fulltext_search handles apostrophes without error" do
+    # Toto pred opravou spôsobilo PG::SyntaxError
+    assert_nothing_raised do
+      Issue.fulltext_search("ivanka pri dunaji'123", against: [ :title ])
+    end
+  end
+
+  test "fulltext_search sanitizes all disallowed tsquery characters" do
+    assert_nothing_raised do
+      Issue.fulltext_search("test'?\\:query", against: [ :title ])
+    end
+  end
+
+  test "fulltext_search returns empty result for only special characters" do
+    issue = issues(:two)
+
+    result = Issue.fulltext_search("'''???", against: [ :title ])
+    assert_empty result
+  end
+
+  test "fulltext_search still works for normal queries" do
+    issue = issues(:two)
+
+    result = Issue.fulltext_search("Bratislava", against: [ :title ])
+    assert_includes result, issue
+  end
+
+  test "sanitize_terms removes apostrophes and splits correctly" do
+    result = Issue.sanitize_terms("ivanka pri dunaji'123")
+    assert_equal [ "ivanka", "pri", "dunaji", "123" ], result
+  end
+
+  test "sanitize_terms removes all disallowed characters and splits correctly" do
+    result = Issue.sanitize_terms("test'?\\:query")
+    assert_equal [ "test", "query" ], result
+  end
+
+  test "sanitize_terms returns empty array for only special characters" do
+    result = Issue.sanitize_terms("'''???")
+    assert_empty result
+  end
+
+  test "sanitize_terms handles normal queries" do
+    result = Issue.sanitize_terms("Bratislava hlavne mesto")
+    assert_equal [ "Bratislava", "hlavne", "mesto" ], result
+  end
+
+  test "sanitize_terms handles mixed input" do
+    result = Issue.sanitize_terms("test'normal\\:mixed?query")
+    assert_equal [ "test", "normal", "mixed", "query" ], result
+  end
+end


### PR DESCRIPTION
The fulltext_search method allowed apostrophes and other special characters in user input that break PostgreSQL tsquery syntax (e.g., ' dunaji'123 ' causes PG::SyntaxError).

Changes:
- Add DISALLOWED_TSQUERY_CHARACTERS regex to filter out 
- Sanitize each search term by replacing ' ? \ : with spaces
- Return empty scope (none) if all terms are sanitized away
- Add tests for apostrophes, special chars, and normal queries

Fixes: ERROR: syntax error in tsquery: "' dunaji'123 '"