### PR TITLE
Fix CMS pages import

### DIFF
--- a/app/jobs/cms/import_page_job.rb
+++ b/app/jobs/cms/import_page_job.rb
@@ -28,7 +28,7 @@ class Cms::ImportPageJob < ApplicationJob
       page.assign_attributes(
         title: topic_raw["title"],
         slug: topic_raw["slug"],
-        tags: topic_raw["tags"],
+        tags: topic_raw["tags"].map { |tag| tag["name"] },
         text: post_raw["cooked"],
         raw: post_raw["raw"],
         category: category,


### PR DESCRIPTION
Zmenil sa format response z discourse API. Predtym API vracalo iba nazvy tagov: `["published"]`, (s cim pocitame pri dalsom spracovani u nas), teraz: `[{"id" => 1, "name" => "published", "slug" => "published"}]`.