### PR TITLE
Sync previous RS only for issues in resolution process

### DIFF
--- a/app/jobs/triage/sync_previous_responsible_subject_job.rb
+++ b/app/jobs/triage/sync_previous_responsible_subject_job.rb
@@ -1,6 +1,8 @@
 module Triage
   class SyncPreviousResponsibleSubjectJob < ApplicationJob
     def perform(issue, previous_responsible_subject, client: TriageZammadEnvironment.client)
+      return unless issue.resolution_process?
+
       client.sync_previous_responsible_subject!(issue.resolution_external_id, previous_responsible_subject)
     end
   end


### PR DESCRIPTION
Posielame do tej metody, kt. vola tento job `issue.resolution_external_id` bez ohladu na to, ci existuje. Vychadza mi, ze trackovat predchadzajuce RS ma zmysel iba pri resolution procese.