### PR TITLE
allow all 2xx status codes for webhooks

### DIFF
--- a/app/jobs/triage/fire_webhook_job.rb
+++ b/app/jobs/triage/fire_webhook_job.rb
@@ -15,6 +15,6 @@ class Triage::FireWebhookJob < ApplicationJob
     }
 
     response = provider.post(client.url, payload.to_json, headers)
-    raise "Unexpected response status: #{response.status}" unless response.status == 204
+    raise "Unexpected response status: #{response.status}" unless response.status&.between?(200, 299)
   end
 end


### PR DESCRIPTION
v dokumentácii píšeme 200, ale v špecifikácii hovoria, že hocijaký 2XX